### PR TITLE
pdata_fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog
 
 4.1 (unreleased)
 ----------------
-
+- Correction of the use of Pdata when editing content
+  (`#23 <https://github.com/zopefoundation/Products.ExternalEditor/issues/23>`_)
 
 4.0 (2023-07-04)
 ----------------

--- a/src/Products/ExternalEditor/ExternalEditor.py
+++ b/src/Products/ExternalEditor/ExternalEditor.py
@@ -49,7 +49,7 @@ class PDataStreamIterator:
         if self.data is None:
             raise StopIteration
         data = self.data.data
-        self.data = next(self.data)
+        self.data = self.data.next
         return data
 
 

--- a/src/Products/ExternalEditor/tests/test_PDataStreamIterator.py
+++ b/src/Products/ExternalEditor/tests/test_PDataStreamIterator.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from OFS.Image import Pdata
+
+from ..ExternalEditor import PDataStreamIterator
+
+
+class Tests(TestCase):
+    def test_empty(self):
+        si = PDataStreamIterator(None)
+        self.assertEqual(list(si), [])
+
+    def test_chained(self):
+        d = Pdata(b"abc")
+        d.next = Pdata(b"def")
+        si = PDataStreamIterator(d)
+        self.assertEqual(list(si), [b"abc", b"def"])


### PR DESCRIPTION
Fix #23 

Correction of the use of `Pdata` when editing content.